### PR TITLE
feat: add deep linking functionality for Discord notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Camera Viewer is designed for scenarios where security cameras automatically rec
 - 🏷️ **Storage indicators** - Visual badges showing S3 storage class
 - 🔒 **Authentication** - Basic HTTP auth protection
 - 📱 **Mobile friendly** - Responsive web interface
+- 🔗 **Deep linking** - Direct links to specific videos (e.g., `/video?key=2024/01/01/video.mp4`)
 - 🐳 **Containerized** - Docker and Docker Compose ready
 
 ## Quick Start

--- a/discord-notifier/.env.example
+++ b/discord-notifier/.env.example
@@ -11,3 +11,6 @@ DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOO
 
 # SQLite database path (optional, defaults to ./discord-notifier.db)
 NOTIFIER_DB_PATH=./discord-notifier.db
+
+# Camera Viewer Web Application URL (for deep linking)
+CAMERA_VIEWER_URL=https://your-camera-viewer-domain.com

--- a/discord-notifier/README.md
+++ b/discord-notifier/README.md
@@ -86,6 +86,7 @@ CMD ["./discord-notifier"]
 | `BUCKET_NAME`           | S3 bucket name          | (required)              |
 | `DISCORD_WEBHOOK_URL`   | Discord webhook URL     | (required)              |
 | `NOTIFIER_DB_PATH`      | Path to SQLite database | `./discord-notifier.db` |
+| `CAMERA_VIEWER_URL`     | Camera Viewer web URL   | (optional)              |
 
 ## How It Works
 
@@ -104,3 +105,4 @@ The notification includes:
 - File size
 - Full S3 key
 - Upload timestamp
+- Direct link to watch the video (if CAMERA_VIEWER_URL is configured)

--- a/index.html
+++ b/index.html
@@ -843,6 +843,34 @@
         }
       });
 
+      async function handleDeepLink() {
+        // Check if we have a video key in the URL
+        const urlParams = new URLSearchParams(window.location.search);
+        const videoKey = urlParams.get('key');
+        
+        if (videoKey) {
+          // Extract date from key (format: YYYY/MM/DD/filename.mp4)
+          const keyParts = videoKey.split('/');
+          if (keyParts.length >= 4) {
+            const year = keyParts[0];
+            const month = keyParts[1];
+            const day = keyParts[2];
+            const filename = keyParts.slice(3).join('/');
+            
+            // Load years and select the correct date
+            await loadYears();
+            await selectYear(year);
+            await selectMonth(month);
+            await selectDay(day);
+            
+            // Play the video
+            setTimeout(() => {
+              playVideo(videoKey, filename);
+            }, 500);
+          }
+        }
+      }
+
       // Auto-refresh latest video every 5 minutes
       setInterval(loadLatestVideo, 5 * 60 * 1000);
 
@@ -850,6 +878,7 @@
       loadYears();
       loadLatestVideo();
       loadStats();
+      handleDeepLink();
     </script>
   </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -490,6 +490,12 @@ func main() {
 		})
 	})
 
+	http.HandleFunc("/video", basicAuth(func(w http.ResponseWriter, r *http.Request) {
+		// Handle deep linking to specific videos
+		// Example: /video?key=2024/01/01/video.mp4
+		http.ServeFile(w, r, "index.html")
+	}))
+
 	http.HandleFunc("/", basicAuth(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "index.html")
 	}))


### PR DESCRIPTION
- Add /video route handler to support deep links
- Update frontend to handle video query parameters and auto-open videos
- Add CAMERA_VIEWER_URL environment variable to Discord notifier
- Include video links in Discord notifications when URL is configured
- Update documentation for both main app and Discord notifier